### PR TITLE
Add support for RSMods `Disable Song Previews` Mod

### DIFF
--- a/RSHelpers/RSMemoryReader.cs
+++ b/RSHelpers/RSMemoryReader.cs
@@ -51,6 +51,8 @@ namespace RockSnifferLib.RSHelpers
             if (preview_name != null)
             {
                 //Verify Play_ prefix and _Preview or _Invalid suffix
+                //_Invalid suffix is applied to all song previews when a RSMods user has the "Disable Song Preview" mod enabled.
+                //_Invalid is used to prevent the song preview from being played in-game, but in this case we want to know when that event is triggered.
                 if (preview_name.StartsWith("Play_") && (preview_name.EndsWith("_Preview") || preview_name.EndsWith("_Invalid")))
                 {
                     //Remove Play_ prefix and _Preview or _Invalid suffix

--- a/RSHelpers/RSMemoryReader.cs
+++ b/RSHelpers/RSMemoryReader.cs
@@ -51,7 +51,7 @@ namespace RockSnifferLib.RSHelpers
             if (preview_name != null)
             {
                 //Verify Play_ prefix and _Preview or _Invalid suffix
-                //_Invalid suffix is applied to all song previews when a RSMods user has the "Disable Song Preview" mod enabled.
+                //_Invalid suffix is applied to all song previews, and replaces _Preview, when a RSMods user has the "Disable Song Preview" mod enabled.
                 //_Invalid is used to prevent the song preview from being played in-game, but in this case we want to know when that event is triggered.
                 if (preview_name.StartsWith("Play_") && (preview_name.EndsWith("_Preview") || preview_name.EndsWith("_Invalid")))
                 {

--- a/RSHelpers/RSMemoryReader.cs
+++ b/RSHelpers/RSMemoryReader.cs
@@ -50,10 +50,10 @@ namespace RockSnifferLib.RSHelpers
             //If there was string in memory
             if (preview_name != null)
             {
-                //Verify Play_ prefix and _Preview suffix
-                if (preview_name.StartsWith("Play_") && preview_name.EndsWith("_Preview"))
+                //Verify Play_ prefix and _Preview or _Invalid suffix
+                if (preview_name.StartsWith("Play_") && (preview_name.EndsWith("_Preview") || preview_name.EndsWith("_Invalid")))
                 {
-                    //Remove Play_ prefix and _Preview suffix
+                    //Remove Play_ prefix and _Preview or _Invalid suffix
                     string song_id = preview_name.Substring(5, preview_name.Length - 13);
 
                     //Assign to readout


### PR DESCRIPTION
Rocksniffer looks for the `_Preview` suffix on the song previews to get the SongKey for the song. To disable song previews, RSMods changes this Wwise event from `Play_{SongKey}_Preview` to `Play_{SongKey}_Invalid` so Wwise doesn't know what event to play.

This will allow Rocksniffer to work while the `Disable Song Previews` mod is enabled.